### PR TITLE
Fix grammar and wording in scenarios

### DIFF
--- a/scenarios/02_High_Pass.cfg
+++ b/scenarios/02_High_Pass.cfg
@@ -179,12 +179,12 @@
         [/message]
         [message]
             speaker=Arwen
-            message= _ "I cannot say with surely."
+            message= _ "I cannot say with certainty."
         [/message]
         [message]
             speaker=Grunk
             # po: He is irritated, but he has no intention of blaming Arwen that much.
-            message= _ "Cease your jokes. Haven’t you actually been unable to let cast aside your attachment for your own people? You’re just happy to see a woman of your race after so long, huh?"
+            message= _ "Cease your jokes. Haven't you actually been unable to cast aside your attachment for your own people? You're just happy to see a woman of your race after so long, huh?"
         [/message]
         [message]
             speaker=Arwen
@@ -222,7 +222,7 @@
         [/message]
         [message]
             speaker=Ellrea
-            message= _ "I will not be fooled. I know you’re one of those bandits who captured me and sought to sell me into bondage. What are you trying to deceive me into doing the next?"
+            message= _ "I will not be fooled. I know you're one of those bandits who captured me and sought to sell me into bondage. What are you trying to deceive me into doing next?"
         [/message]
         [message]
             speaker=Grunk
@@ -246,7 +246,7 @@
         [/message]
         [message]
             speaker=Arwen
-            message= _ "A virtuous elf do prize gratitude and courtesy, no?"
+            message= _ "A virtuous elf does prize gratitude and courtesy, no?"
         [/message]
 
         {DELAY 250}
@@ -463,7 +463,7 @@
         [/message]
         [message]
             speaker=Arwen
-            message= _ "That’s enough, peace your mouth."
+            message= _ "That's enough, hold your tongue."
         [/message]
 
         [scroll_to_unit]
@@ -666,7 +666,7 @@
         [/message]
         [message]
             speaker=Arwen
-            message= _ "Aye, but in sooth... my homeland is Greenwood, just like as is this girl’s. If I am to trust her earlier utterance, it seems the forest is now being invaded by the undead."
+            message= _ "Aye, but in sooth... my homeland is Greenwood, just as is this girl's. If I am to trust her earlier utterance, it seems the forest is now being invaded by the undead."
         [/message]
         [message]
             speaker=Grunk

--- a/scenarios/03_Clash_with_the_Abysses.cfg
+++ b/scenarios/03_Clash_with_the_Abysses.cfg
@@ -49,7 +49,7 @@
             {GWT_BIGMAP}
         [/part]
         [part]
-            story= _ "The first few days seemed to went well, save for the girl who still mistrusted me, casting wary glances. But by degrees, we began to shiver in the foul air of the wasteland. The undead’s encroachment was beyond what we had foreseen. As we pressed on, the tokens of their slaughter, and their warriors themselves, sawed ever more manifest. To lessen our contact with them, we took two or three detours."
+            story= _ "The first few days seemed to go well, save for the girl who still mistrusted me, casting wary glances. But by degrees, we began to shiver in the foul air of the wasteland. The undead's encroachment was beyond what we had foreseen. As we pressed on, the tokens of their slaughter, and their warriors themselves, grew ever more manifest. To lessen our contact with them, we took two or three detours."
             {GWT_BIGMAP}
             show_title=yes
         [/part]
@@ -593,11 +593,11 @@
         name=malin escapes
         [message]
             speaker=Mal Keshar
-            message= _ "Elf, your foolish struggle has not been so bad for me. So I shall give you a morsel of counsel! Behind those undead may lurk a being <i>darker</i> than you imagine. They are mastered by a magic somewhat unlike from what I know."
+            message= _ "Elf, your foolish struggle has not been so bad for me. So I shall give you a morsel of counsel! Behind those undead may lurk a being <i>darker</i> than you imagine. They are mastered by a magic somewhat unlike what I know."
         [/message]
         [message]
             speaker=Mal Keshar
-            message= _ "I, Mal Keshar, have spread numerous spies throughout the Northlands in preparation for the coming war against the orcs. A few years ago, I sensed a strange magic growing at the verge of the Mountains of Haag. And in the last year, I received a report of dark forces seeking contact to the Silent Forest. I am sure these matters are some kind of omen."
+            message= _ "I, Mal Keshar, have spread numerous spies throughout the Northlands in preparation for the coming war against the orcs. A few years ago, I sensed a strange magic growing at the verge of the Mountains of Haag. And in the last year, I received a report of dark forces seeking contact with the Silent Forest. I am sure these matters are some kind of omen."
         [/message]
         [message]
             speaker=Arwen


### PR DESCRIPTION
Correct grammar and wording in dialogues across two scenario files Files: scenarios/02_High_Pass.cfg and scenarios/03_Clash_with_the_Abysses.cfg These are non-functional text edits.